### PR TITLE
Fix typo in clear call, red used for both red and green.

### DIFF
--- a/tutorial.js
+++ b/tutorial.js
@@ -11,7 +11,7 @@
  *  - https://github.com/chinedufn/load-collada-dae
  */
 function drawBackground (gl, color) {
-  gl.clearColor(color[0], color[2], color[2], 1)
+  gl.clearColor(color[0], color[1], color[2], 1)
   gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
 }
 


### PR DESCRIPTION
Thanks a lot for the great introduction.  I fixed a tiny mistake in the clear call.

Is it easy for you to update the article

`  gl.clear()
`
to match this repo

`  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
`
as the version of the clear call in the article results in a transparent image.